### PR TITLE
Fixed 'Invariant Exception: Element type is invalid' 

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -5,7 +5,7 @@ import RavenReactNative from "raven-js/plugins/react-native";
 import { sentryDsn } from "enlist/app/config";
 import Package from "enlist/package.json";
 
-import { COLOR, ThemeProvider } from "react-native-material-ui";
+import { COLOR, ThemeContext, getTheme } from "react-native-material-ui";
 
 const uiTheme = {
   palette: {
@@ -35,9 +35,9 @@ class enlist extends Component {
       <View style={{ flex: 1, backgroundColor: "white" }}>
         <StatusBar barStyle="default" />
         <ActionSheetProvider>
-          <ThemeProvider uiTheme={uiTheme}>
+          <ThemeContext.Provider value={getTheme(uiTheme)}>
             <Enlist />
-          </ThemeProvider>
+          </ThemeContext.Provider>
         </ActionSheetProvider>
       </View>
     );


### PR DESCRIPTION
I found that Invariant Exception Element type, sometimes happens when the class is not found:
https://github.com/facebook/react-native/issues/17527

The error indicated it was `ActionSheetProvider` but ActionSheetProvider was exporting it's class correctly.  And also `Enlist` was being exported.  So that leaves the thing in the middle: `ThemeProvider` when I looked inside the `react-native-material-ui` module there was no `ThemeProvider` in the main exports, so then I looked up the instructions and implemented it that way:

Here's the instructions I followed: https://github.com/xotahal/react-native-material-ui/blob/master/docs/Usage.md

Note: This PR goes into `update-compile` not master.